### PR TITLE
If invalid ip address or router info provided for ping trace page, th…

### DIFF
--- a/openstack_dashboard/don/ovs/path.py
+++ b/openstack_dashboard/don/ovs/path.py
@@ -421,6 +421,13 @@ def path (params):
     src_info = get_port_info(info, src_ip)
     dst_info = get_port_info(info, dst_ip)
 
+    if src_info == None:
+        return "Source ip not found on the network"
+    if dst_info == None:
+        return "Destination ip not found on the network"
+    if qrouter == None:
+        return "No such router information found on the network"
+
     # src and dst are in the same network
     if src_info['tag'] == dst_info['tag']:
         path_same_network(params)

--- a/openstack_dashboard/don/ovs/views.py
+++ b/openstack_dashboard/don/ovs/views.py
@@ -128,7 +128,11 @@ def ping(request):
                     'debug'     : True,
                     'plot'      : False,
                     }
-            path.path(params)
+            response = path.path(params)
+            if response:
+                error_text = response
+                messages.error(request,error_text)
+                return render(request, 'don/ovs/ping.html', {'form': form})
 
             JSON_FILE = pwd + '/don/ovs/don.json'
             COMPUTE_DOT_FILE  = None


### PR DESCRIPTION
In ping trace page, When providing ip address or router info which is not available on network, throws exception
